### PR TITLE
Fix empty Molecules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,20 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.19.1
     hooks:
       - id: pyupgrade
         args: ["--keep-runtime-typing"]
   - repo: https://github.com/myint/autoflake
-    rev: v2.1.1
+    rev: v2.3.1
     hooks:
       - id: autoflake
         args: ["--in-place", "--remove-all-unused-imports"]
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 24.10.0
     hooks:
       - id: black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.26.1"]
 build-backend = "hatchling.build"
 
 [project]

--- a/tests/test_molecules.py
+++ b/tests/test_molecules.py
@@ -299,5 +299,18 @@ def test_local_coordinates():
 
 
 def test_sort():
-    mol = Molecules(np.zeros((4, 3)), features={"A": [0.1, 0.2, 0.4, 0.3]})
-    mol.sort("A")
+    pos = np.stack([np.arange(4)] * 3, axis=1)
+    mol = Molecules(pos, features={"A": [11, 12, 14, 13]})
+    mol_sorted = mol.sort("A")
+    assert mol_sorted.features["A"].to_list() == [11, 12, 13, 14]
+    assert mol_sorted.pos[:, 0].tolist() == [0, 1, 3, 2]
+
+
+def test_concat_molecules():
+    mole0 = Molecules(np.zeros((4, 3)), features={"A": [1, 2, 3, 4]})
+    mole1 = Molecules.empty(feature_labels=["A"])
+    mole2 = Molecules(np.ones((2, 3)), features={"A": [5, 6]})
+    mole = Molecules.concat([mole0, mole1, mole2], concat_features=True)
+    assert mole.count() == 6
+    assert_allclose(mole.pos, np.vstack([np.zeros((4, 3)), np.ones((2, 3))]))
+    assert mole.features["A"].to_list() == [1, 2, 3, 4, 5, 6]

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,6 +1,6 @@
 import numpy as np
 from acryo import TomogramSimulator, Molecules
-from acryo.testing import spiral
+from acryo.testing import spiral, blobs
 import polars as pl
 
 
@@ -44,3 +44,30 @@ def test_simulator_2d():
     sim = sim.replace(scale=0.5, order=1).copy()
     out = sim.simulate_2d((100, 100))
     assert out.shape == (100, 100)
+
+
+def test_simulate_projection():
+    img = blobs()
+    sim = TomogramSimulator()
+    pos = np.array([[40, 40, 40], [30, 40, 30], [40, 30, 40]])
+    vec = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    mole = Molecules.from_rotvec(pos, vec)
+    sim.add_molecules(mole, img, name="test")
+    sim.simulate_projection(
+        (100, 100), center=(35, 35, 35), xaxis=(0, 0, 1), yaxis=(0, 1, 0)
+    )
+    out = sim.simulate_projection(
+        (100, 100), center=(35, 35, 35), xaxis=(0, 1, 1), yaxis=(0, -1, 1)
+    )
+    assert out.shape == (100, 100)
+
+
+def test_simulate_tilt_series():
+    img = blobs()
+    sim = TomogramSimulator()
+    pos = np.array([[40, 40, 40], [30, 40, 30], [40, 30, 40]])
+    vec = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    mole = Molecules.from_rotvec(pos, vec)
+    sim.add_molecules(mole, img, name="test")
+    out = sim.simulate_tilt_series([-30, 0, 45], (80, 80, 80))
+    assert out.shape == (3, 80, 80)


### PR DESCRIPTION
Empty `Rotation` is now allowed in scipy>1.15.
This PR fixes this