### PR TITLE
Fix inverting a vector

### DIFF
--- a/acryo/__init__.py
+++ b/acryo/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.15"
+__version__ = "0.4.16"
 
 from acryo.loader import SubtomogramLoader, BatchLoader, MockLoader
 from acryo.molecules import Molecules

--- a/acryo/molecules/_rotation.py
+++ b/acryo/molecules/_rotation.py
@@ -25,10 +25,17 @@ def _get_align_rotator(src, dst) -> Rotation:
     """R.apply(src) == dst. Both length must be 1."""
     if np.all(np.abs(src + dst) < 1e-6):
         # Cross product cannot be used for antiparallel vectors.
-        # Use Rodrigues' rotation formula instead to obtain the rotation matrix that
-        # rotates v to -v: R = I - 2vv^T.
-        mat = np.eye(3) - 2 * np.outer(src, src)
-        return Rotation.from_matrix(mat)
+        src = np.atleast_2d(src)
+        # both rotvec_0 and rotvec_1 are orthogonal to src.
+        rotvec_0 = np.stack([np.zeros(src.shape[0]), -src[:, 2], src[:, 1]], axis=1)
+        rotvec_1 = np.stack([src[:, 2], np.zeros(src.shape[0]), -src[:, 0]], axis=1)
+        rotvec = np.where(
+            np.linalg.norm(rotvec_0, axis=1) > np.linalg.norm(rotvec_1, axis=1),
+            rotvec_0,
+            rotvec_1,
+        )
+        rotvec /= np.linalg.norm(rotvec, axis=1, keepdims=True)
+        return Rotation.from_rotvec(rotvec * np.pi)
     cross = np.cross(src, dst)
     sin = norm = np.sqrt(np.sum(cross**2, axis=1, keepdims=True))
     cos = np.sum(src * dst, axis=1, keepdims=True)

--- a/acryo/molecules/_rotation.py
+++ b/acryo/molecules/_rotation.py
@@ -24,8 +24,11 @@ def axes_to_rotator(z: ArrayLike | None, y: ArrayLike) -> Rotation:
 def _get_align_rotator(src, dst) -> Rotation:
     """R.apply(src) == dst. Both length must be 1."""
     if np.all(np.abs(src + dst) < 1e-6):
-        # cross product cannot be used for antiparallel vectors
-        return Rotation.from_matrix(-np.eye(3))
+        # Cross product cannot be used for antiparallel vectors.
+        # Use Rodrigues' rotation formula instead to obtain the rotation matrix that
+        # rotates v to -v: R = I - 2vv^T.
+        mat = np.eye(3) - 2 * np.outer(src, src)
+        return Rotation.from_matrix(mat)
     cross = np.cross(src, dst)
     sin = norm = np.sqrt(np.sum(cross**2, axis=1, keepdims=True))
     cos = np.sum(src * dst, axis=1, keepdims=True)

--- a/tests/test_molecules.py
+++ b/tests/test_molecules.py
@@ -290,6 +290,14 @@ def test_axes_to_rotator(rotvec: list[float]):
     assert_allclose(out.as_rotvec(), [rotvec], rtol=1e-8, atol=1e-8)
 
 
+def test_axes_to_rotator_invert():
+    z = [[-1, 0, 0]]
+    y = [[0, -1, 0]]
+    assert_allclose(
+        axes_to_rotator(z, y).as_rotvec(), [[0, 0, np.pi]], rtol=1e-8, atol=1e-8
+    )
+
+
 def test_local_coordinates():
     mol = Molecules(np.zeros((1, 3)), Rotation.random(1))
     coords = mol.local_coordinates((3, 4, 5), squeeze=False)


### PR DESCRIPTION
This PR fixes the bug when trying to align `v` to `-v`